### PR TITLE
EDM4hep capitalization convention, Minor text editing

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,9 +1,9 @@
 !!!IMPORTANT!!!: To facilitate faster and easier response to your issue please provide in addition to the description of the issue also the following information
 
- - OS version: e.g. SLC6
- - Compiler version: e.g GCC 6.2
- - EDM4Hep version: tag or commit ID, or GitHub branch
- - Reproduced by: exact steps to reproduce the problem: checkout, setup environment (Geant, ROOT versions, iLCSoft release), cmake, build, run...
+ - OS version: e.g. centos7
+ - Compiler version: e.g GCC 8.0
+ - EDM4hep version: tag or commit ID, or GitHub branch
+ - Reproduced by: exact steps to reproduce the problem: checkout, setup environment (ROOT versions, LCG release), cmake, build, run...
  - Input: link to input files if applicable
  - Output: full build and run log output
  - Goal: A short description of what you are trying to achieve

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![Build Status](https://travis-ci.com/HSF/EDM4HEP.svg?branch=master)](https://travis-ci.com/HSF/EDM4HEP)
 
-# EDM4Hep
+# EDM4hep
 
 
 A generic event data model for HEP collider experiments.
@@ -14,5 +14,5 @@ This project has just started and is still very experiemental.
 
 ## Contributing
 
-See our [contributing guidelines](./doc/contributing.md) if you want to contribute code to EDM4Hep.
+See our [contributing guidelines](./doc/contributing.md) if you want to contribute code to EDM4hep.
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,11 +1,11 @@
-# Contributing to EDM4Hep
+# Contributing to EDM4hep
 
-Please read these guidelines if you want to contribute to the EDM4Hep project.
+Please read these guidelines if you want to contribute to the EDM4hep project.
 
 
 ## Git workflow
 
-For EDM4Hep we would like to follow a so called "No Switch Yard" (NoSY) workflow.
+For EDM4hep we would like to follow a so called "No Switch Yard" (NoSY) workflow.
 
 In essence this means that you develop your (small) new feature in a dedicated
 *feature branch* that is kept up to date with the master branch until you create
@@ -14,9 +14,9 @@ a PR, as we only allow *rebase merges* for PRs.
 
 ### Example workflow
 
-- checkout a copy of EDM4Hep from the origin at AIDASoft:
+- checkout a copy of EDM4hep from the origin at HSF:
 
-	 git clone https://github.com/AIDASoft/EDM4HEP.git
+	 git clone https://github.com/HSF/EDM4HEP.git
 	 cd EDM4HEP
 	
 - create a fork of the repository on the Github web page
@@ -35,7 +35,7 @@ a PR, as we only allow *rebase merges* for PRs.
       git fetch origin; git rebase origin/master
 	
 
-- after having committed everything to your new branch, push it to your fork of EDM4Hep:
+- after having committed everything to your new branch, push it to your fork of EDM4hep:
 
       git push downstream <myNewBranch>
 
@@ -44,7 +44,7 @@ a PR, as we only allow *rebase merges* for PRs.
   - now you can create a pull request on the web site
 
 
-### Release Notes
+### Release Notes 
 
 Please make sure you fill in meaningful release notes in the comment field that is
 provided at the Github web page when creating the PR, e.g.


### PR DESCRIPTION
I propose to stick to the DD4hep spelling convention of writing `EDM4hep` in mixed case, `EDM4HEP` in the context of all caps and `edm4hep` in code for ease of typing. So no `EDM4Hep`, that hopefully means less memorization effort!

BEGINRELEASENOTES
- Fix edm4hep spelling convention

ENDRELEASENOTES