### PR TITLE
Build podio dependency on the fly in CI builds

### DIFF
--- a/.edm4hep-ci.d/compile_and_test_with_podio.sh
+++ b/.edm4hep-ci.d/compile_and_test_with_podio.sh
@@ -1,0 +1,12 @@
+source init.sh
+cd ..
+git clone https://github.com/AIDASoft/podio || true
+cd podio
+mkdir build install
+cd build
+ cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=../install ..
+make -j 4 install
+cd ..
+export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+cd ../EDM4HEP
+./.edm4hep-ci.d/compile_and_test.sh

--- a/.edm4hep-ci.d/compile_and_test_with_podio.sh
+++ b/.edm4hep-ci.d/compile_and_test_with_podio.sh
@@ -1,6 +1,5 @@
 source init.sh
-cd ..
-git clone https://github.com/AIDASoft/podio || true
+git clone --depth 1 https://github.com/AIDASoft/podio || true
 cd podio
 mkdir build install
 cd build
@@ -8,5 +7,6 @@ cd build
 make -j 4 install
 cd ..
 export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
-cd ../EDM4HEP
+export PODIO=$PWD/install:$CMAKE_PREFIX_PATH
+cd ..
 ./.edm4hep-ci.d/compile_and_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 # command to run tests
 script: 
-  - docker run -it -v ${PWD}:/workspace -w /workspace  --privileged -e LHCB_ENV_MODE=none -u 0:0 -e USER=root -e GROUP=root -e CMTCONFIG=x86_64-centos7-gcc8-opt  gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:latest bash -c "./.edm4hep-ci.d/compile_and_test.sh"
+  - docker run -it -v ${PWD}:/workspace -w /workspace  --privileged -e LHCB_ENV_MODE=none -u 0:0 -e USER=root -e GROUP=root -e CMTCONFIG=x86_64-centos7-gcc8-opt  gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:latest bash -c "./.edm4hep-ci.d/compile_and_test_with_podio.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 # command to run tests
 script: 
-  - docker run -it -v ${PWD}:/workspace -w /workspace  --privileged -e LHCB_ENV_MODE=none -u 0:0 -e USER=root -e GROUP=root -e CMTCONFIG=x86_64-centos7-gcc8-opt  gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:latest bash -c "./.edm4hep-ci.d/compile_and_test_with_podio.sh"
+  - docker run -it -v ${PWD}:/workspace -w /workspace  --privileged -e LHCB_ENV_MODE=none -u 0:0 -e USER=root -e GROUP=root -e CMTCONFIG=x86_64-centos7-gcc8-opt  gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:latest bash -c "pwd; ls ;./.edm4hep-ci.d/compile_and_test_with_podio.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,12 @@ env:
     - COMPILER=gcc
 
 before_install:
-  - wget https://gitlab.cern.ch/lhcb-core/LbDocker/raw/master/scripts/lb-docker-run 
-  - chmod a+x lb-docker-run
+  - docker pull gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:latest
 
 
 # command to run tests
 script: 
-  - sudo ./lb-docker-run --centos7 --no-lblogin --force-cvmfs ./.edm4hep-ci.d/compile_and_test.sh 
+  - docker run -it -v ${PWD}:/workspace -w /workspace  --privileged -e LHCB_ENV_MODE=none -u 0:0 -e USER=root -e GROUP=root -e CMTCONFIG=x86_64-centos7-gcc8-opt  gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:latest bash -c "./.edm4hep-ci.d/compile_and_test.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(EDM4HEP VERSION 0.1.0)
 
 find_package(podio REQUIRED HINTS $ENV{PODIO})
 
-execute_process(COMMAND python ${podio_CMAKE_DIR}/../python/podio_class_generator.py edm4hep.yaml edm4hep edm4hep
+execute_process(COMMAND python ${podio_DIR}/../../../python/podio_class_generator.py edm4hep.yaml edm4hep edm4hep
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 link_directories(${podio_LIBRARY_DIR})
@@ -25,7 +25,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}
   ${PROJECT_BINARY_DIR}
   ${ROOT_INCLUDE_DIR}
-  ${podio_INCLUDE_DIRS} # Has to be changed to podio_INCLUDE_DIR with next update of podio
+  ${podio_INCLUDE_DIR}
   )
 
 #--- Define basic build settings -----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}
   ${PROJECT_BINARY_DIR}
   ${ROOT_INCLUDE_DIR}
-  ${podio_INCLUDE_DIR}
+  ${podio_INCLUDE_DIRS} # Has to be changed to podio_INCLUDE_DIR with next update of podio
   )
 
 #--- Define basic build settings -----------------------------------------------


### PR DESCRIPTION

It's certainly better to take podio from some nightlies on cvmfs, but as a stopgap solution this builds podio on the fly in CI jobs, works well enough for now.

As @graeme-a-stewart remarked, the lhcb docker run script is a bit overkill, so I replaced it with a direct call to `docker run`. 

BEGINRELEASENOTES
* Use an extended script for CI builds that compiles and install the HEAD of podio on the fly. 
ENDRELEASENOTES