### PR TITLE
All Remaining Types for a First Working Version

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -265,3 +265,118 @@ datatypes :
       - edm4hep::Cluster        clusters     //clusters that have been combined to this cluster.
       - edm4hep::CalorimeterHit hits         //hits that have been combined to this cluster.
       - edm4hep::ParticleID     particleIDs  //particle IDs (sorted by their likelihood) 
+
+  #-------------  TrackerHit
+  edm4hep::TrackerHit:
+    Description : "Tracker hit"
+    Author : "F.Gaede, DESY"
+    Members :
+      - unsigned long long cellID      //ID of the sensor that created this hit
+      - int type                       //type of raw data hit, either one of edm4hep::TPCHIT, edm4hep::SIMTRACKERHIT - see collection parameters "TrackerHitTypeNames" and "TrackerHitTypeValues". 
+      - int quality                    //quality bit flag of the hit.    
+      - float time                     //time of the hit.
+      - float eDep                     //energy deposited on the hit [GeV]. 
+      - float eDepError                //error measured on EDep [GeV].
+      - float edx                      //dE/dx of the hit in [GeV]. 
+      - edm4hep::Vector3d position     //hit position in [mm].
+      - std::array<float,6> covMatrix  //covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
+    VectorMembers:
+      - edm4hep::ObjectID  rawHits       //raw data hits. Check getType to get actual data type. 
+
+
+ #----------  TPCHit
+  edm4hep::TPCHit:
+    Description: "Time Projection Chamber Hit"
+    Author : "F.Gaede, DESY"
+    Members:
+       - unsigned long long cellID  //detector specific cell id. 
+       - int quality                //quality flag for the hit. 
+       - float time                 //time of the hit. 
+       - float charge               //integrated charge of the hit. 
+    VectorMembers:
+       - int rawDataWords          //raw data (32-bit) word at i.
+
+ #-------- Track 
+  edm4hep::Track:
+    Description: "Reconstructed track"
+    Author : "F.Gaede, DESY"
+    Members:
+      - int type                         //flagword that defines the type of track.Bits 16-31 are used internally
+      - float chi2                       //Chi^2 of the track fit
+      - int ndf                          //number of degrees of freedom of the track fit
+      - float dEdx                       //dEdx of the track.
+      - float dEdxError                  //error of dEdx.
+      - float radiusOfInnermostHit       //radius of the innermost hit that has been used in the track fit
+    VectorMembers:
+      - int subDetectorHitNumbers        //number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices 
+      - edm4hep::TrackState trackStates  //track states
+    OneToManyRelations:
+      - edm4hep::TrackerHit trackerHits  //hits that have been used to create this track
+      - edm4hep::Track tracks            //tracks (segements) that have been combined to create this track
+
+ #---------- Vertex
+  edm4hep::Vertex:
+    Description: "LCIO vertex"
+    Author : "F.Gaede, DESY"
+    Members:
+      - int                 primary       //boolean flag, if vertex is the primary vertex of the event
+      - float               chi2          //chi-squared of the vertex fit
+      - float               probability   //probability of the vertex fit
+      - edm4hep::Vector3f   position      // [mm] position of the vertex.
+      - std::array<float,6> covMatrix     //covariance matrix of the position (stored as lower triangle matrix, i.e. cov(xx),cov(y,x),cov(z,x),cov(y,y),... )
+      - int                 algorithmType //type code for the algorithm that has been used to create the vertex - check/set the collection parameters AlgorithmName and AlgorithmType. 
+    VectorMembers:
+      - float               parameters    //additional parameters related to this vertex - check/set the collection parameter "VertexParameterNames" for the parameters meaning. 
+    OneToOneRelations:
+      - edm4hep::ReconstructedParticle   associatedParticle //reconstructed particle associated to this vertex.
+
+
+  #------- ReconstructedParticle
+  edm4hep::ReconstructedParticle:
+    Description: "Reconstructed Particle"
+    Author : "F.Gaede, DESY"
+    Members:
+      - int                    type           //type of reconstructed particle. Check/set collection parameters ReconstructedParticleTypeNames and ReconstructedParticleTypeValues.
+      - float                  energy         // [GeV] energy of the reconstructed particle.
+      - edm4hep::Vector3f      momentum       // [GeV] particle momentum
+      - edm4hep::Vector3f      referencePoint // [mm] reference, i.e. where the particle has been measured
+      - float                  charge         //charge of the reconstructed particle.
+      - float                  mass           // [GeV] mass of the reconstructed particle, set independently from four vector
+      - float                  goodnessOfPID  //overall goodness of the PID on a scale of [0;1]
+      - std::array<float,10>   covMatrix      //cvariance matrix of the reconstructed particle 4vector (10 parameters). Stored as lower triangle matrix of the four momentum (px,py,pz,E), i.e. cov(px,px), cov(py,##
+    OneToOneRelations:
+      - edm4hep::Vertex          startVertex    //start vertex associated to this particle
+      - edm4hep::ParticleID      particleIDUsed //particle Id used for the kinematics of this particle
+    OneToManyRelations:
+      - edm4hep::Cluster               clusters     //clusters that have been used for this particle. 
+      - edm4hep::Track                 tracks       //tracks that have been used for this particle. 
+      - edm4hep::ReconstructedParticle particles    //reconstructed particles that have been combined to this particle.
+      - edm4hep::ParticleID            particleIDs  //particle Ids (not sorted by their likelihood) 
+    ExtraCode:
+      declaration: "
+      bool isCompound() { return particles_size() > 0 ;}\n
+      //vertex where the particle decays This method actually returns the start vertex from the first daughter particle found.\n 
+      //TODO: edm4hep::Vertex  getEndVertex() { return  edm4hep::Vertex(  (getParticles(0).isAvailable() ? getParticles(0).getStartVertex() :  edm4hep::Vertex(0,0) ) ) ; }\n     
+      "
+
+  edm4hep::MCRecoParticleAssociation:
+    Description: "Used to keep track of the correspondence between MC and reconstructed particles"
+    Author: "C. Bernet, B. Hegner"
+    OneToOneRelations :
+     - edm4hep::ReconstructedParticle  rec // Reference to the reconstructed particle
+     - edm4hep::MCParticle sim // Reference to the Monte-Carlo particle
+
+
+  edm4hep::MCRecoCaloAssociation:
+    Description: "Association between a CaloHit and the corresponding simulated CaloHit"
+    Author: "C. Bernet, B. Hegner"
+    OneToOneRelations:
+     - edm4hep::CalorimeterHit rec // The reconstructed hit.
+     - edm4hep::SimCalorimeterHit sim // The simulated hit.
+
+  edm4hep::MCRecoTrackerAssociation:
+    Description: "Association between a TrackerHit and the corresponding simulated CaloHit"
+    Author : "C. Bernet, B. Hegner"
+    OneToOneRelations:
+     - edm4hep::TrackerHit rec // The reconstructed hit.
+     - edm4hep::SimTrackerHit sim // The simulated hit.

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -48,7 +48,7 @@ components:
         "
       # Parametrized description of a particle track
     edm4hep::TrackState:
-      location       : int # for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex|LastLocation}
+      location       : int # for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex}|LastLocation
       D0             : float # transverse impact parameter
       phi            : float # azimuthal angle 
       omega          : float # is the signed curvature of the track in [1/mm].
@@ -174,10 +174,10 @@ datatypes :
       static const int  BITProducedBySecondary = 30;\n
       bool isOverlay() const { return getQuality() & (1 << BITOverlay) ; }\n
       bool isProducedBySecondary() const { return getQuality() & (1 << BITProducedBySecondary) ; }\n
-      double x() const {return getPosition()[0];};\n
-      double y() const {return getPosition()[1];};\n
-      double z() const {return getPosition()[2];};\n
-      double rho() const {return sqrt(pow(getPosition()[1],2) + pow(getPosition()[0],2));};\n
+      double x() const {return getPosition()[0];}\n
+      double y() const {return getPosition()[1];}\n
+      double z() const {return getPosition()[2];}\n
+      double rho() const {return sqrt(x()*x() + y()*y());}\n
       "
       declaration: "
       int  set_bit(int val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }\n
@@ -277,7 +277,7 @@ datatypes :
       - float time                     //time of the hit.
       - float eDep                     //energy deposited on the hit [GeV]. 
       - float eDepError                //error measured on EDep [GeV].
-      - float edx                      //dE/dx of the hit in [GeV]. 
+      - float edx                      //dE/dx of the hit in [GeV/mm]. 
       - edm4hep::Vector3d position     //hit position in [mm].
       - std::array<float,6> covMatrix  //covariance of the position (x,y,z), stored as lower triangle matrix. i.e. cov(x,x) , cov(y,x) , cov(y,y) , cov(z,x) , cov(z,y) , cov(z,z)
     VectorMembers:
@@ -312,11 +312,11 @@ datatypes :
       - edm4hep::TrackState trackStates  //track states
     OneToManyRelations:
       - edm4hep::TrackerHit trackerHits  //hits that have been used to create this track
-      - edm4hep::Track tracks            //tracks (segements) that have been combined to create this track
+      - edm4hep::Track tracks            //tracks (segments) that have been combined to create this track
 
  #---------- Vertex
   edm4hep::Vertex:
-    Description: "LCIO vertex"
+    Description: "Vertex"
     Author : "F.Gaede, DESY"
     Members:
       - int                 primary       //boolean flag, if vertex is the primary vertex of the event
@@ -375,7 +375,7 @@ datatypes :
      - edm4hep::SimCalorimeterHit sim // The simulated hit.
 
   edm4hep::MCRecoTrackerAssociation:
-    Description: "Association between a TrackerHit and the corresponding simulated CaloHit"
+    Description: "Association between a TrackerHit and the corresponding simulated TrackerHit"
     Author : "C. Bernet, B. Hegner"
     OneToOneRelations:
      - edm4hep::TrackerHit rec // The reconstructed hit.

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -167,11 +167,17 @@ datatypes :
     OneToOneRelations:
       - edm4hep::MCParticle MCParticle //MCParticle that caused the hit.
     ExtraCode :
+      includes: "#include <math.h>\n
+      "
       const_declaration: "
       static const int  BITOverlay = 31;\n
       static const int  BITProducedBySecondary = 30;\n
       bool isOverlay() const { return getQuality() & (1 << BITOverlay) ; }\n
       bool isProducedBySecondary() const { return getQuality() & (1 << BITProducedBySecondary) ; }\n
+      double x() const {return getPosition()[0];};\n
+      double y() const {return getPosition()[1];};\n
+      double z() const {return getPosition()[2];};\n
+      double rho() const {return sqrt(pow(getPosition()[1],2) + pow(getPosition()[0],2));};\n
       "
       declaration: "
       int  set_bit(int val, int num, bool bitval){ return (val & ~(1<<num)) | (bitval << num); }\n

--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -46,6 +46,38 @@ components:
         bool operator==(const Vector2i& v) const { return (a==v.a&&b==v.b) ; }\n
         int operator[](unsigned i) const { return *( &a + i ) ; }\n
         "
+      # Parametrized description of a particle track
+    edm4hep::TrackState:
+      location       : int # for use with At{Other|IP|FirstHit|LastHit|Calorimeter|Vertex|LastLocation}
+      D0             : float # transverse impact parameter
+      phi            : float # azimuthal angle 
+      omega          : float # is the signed curvature of the track in [1/mm].
+      Z0             : float # longitudinal impact parameter
+      tanLambda      : float # lambda is the dip angle of the track in r-z
+      referencePoint : edm4hep::Vector3f # Reference point of the track parameters, e.g. the origin at the IP, or the position  of the first/last hits or the entry point into the calorimeter.
+      covMatrix      : std::array<float,15> # upper triangular covariance matrix of the track parameters.  the order of parameters is:   d0, phi, omega, z0, tan(lambda). 
+      ExtraCode :
+        const_declaration: "
+        static const int AtOther = 0 ; // any location other than the ones defined below\n   
+        static const int AtIP = 1 ;\n
+        static const int AtFirstHit = 2 ;\n                   
+        static const int AtLastHit = 3 ;\n                  
+        static const int AtCalorimeter = 4 ;\n                
+        static const int AtVertex = 5 ;\n     
+        static const int LastLocation = AtVertex  ;\n
+        "
+
+    #------ ObjectID helper struct for references/relations
+    edm4hep::ObjectID:
+      index        : int
+      collectionID : int
+      ExtraCode :
+        includes: "#include <podio/ObjectID.h>\n"
+        declaration: "
+        ObjectID() = default;\n
+        ObjectID(const podio::ObjectID& id ): index(id.index), collectionID(id.collectionID) {}\n
+      "
+
 
 datatypes :
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add plcio-like types and some associations needed for a first working version: TrackState, ObjectID, TrackerHit, TPCHit, Track, Vertex, ReconstructedParticle, MCRecoParticleAssociation, MCRecoTrackerAssociation, MCRecoCaloAssociation

ENDRELEASENOTES