### PR TITLE
Add configuration for github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: self-hosted
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: compile and test
+      run: |
+        ./.edm4hep-ci.d/compile_and_test_with_podio.sh

--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,9 @@ TOOLSPATH=/cvmfs/fcc.cern.ch/sw/0.8.3/tools/
 OS=`python $TOOLSPATH/hsf_get_platform.py --get os`
 
 # source FCC externals
-source /cvmfs/fcc.cern.ch/sw/views/releases/externals/94.2.0/x86_64-$OS-gcc62-opt/setup.sh
+source /cvmfs/fcc.cern.ch/sw/latest/setup.sh
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/CMake/3.11.1-773ff/x86_64-centos7-gcc8-opt/bin/:$PATH
+
 
 
 


### PR DESCRIPTION
Since we are experiencing issues with TravisCI, I had a quick look at github actions. This PR adds the necessary configuration files and updates the setup. I'm using a runner hosted on openstack, which allows us to take advantage of the cvmfs cache. It's working on my fork, but  before enabling this here, I think there is a need for discussion.


BEGINRELEASENOTES
- add configuration for github actions

ENDRELEASENOTES