### PR TITLE
Build System: Ensure that  CI picks up local version of packages also present in LCG

### DIFF
--- a/.edm4hep-ci.d/compile_and_test_with_podio.sh
+++ b/.edm4hep-ci.d/compile_and_test_with_podio.sh
@@ -24,4 +24,10 @@ ninja install
 cd ..
 export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
 cd ..
-./.edm4hep-ci.d/compile_and_test.sh
+# edm4hep
+mkdir build install
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -G Ninja .. 
+ninja -k0
+ninja install
+ctest --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ install
 edm4hep/edm4hep
 edm4hep/src
 
+# CI subfolders
+podio/
+tricktrack/
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
Because the init script was sourced twice [here] (https://github.com/HSF/EDM4hep/blob/master/.edm4hep-ci.d/compile_and_test.sh#L2), the local CI builds of dependencies were not correctly picked up.
BEGINRELEASENOTES
- build system bugfix: Ensure that the CI picks up local version of packages also present in LCG
ENDRELEASENOTES